### PR TITLE
Updating The meaning of Underscore Tutorial

### DIFF
--- a/Python/04. Advanced/01. The Meaning of Underscore (_).ipynb
+++ b/Python/04. Advanced/01. The Meaning of Underscore (_).ipynb
@@ -1,1 +1,855 @@
-{"cells": [{"cell_type": "markdown", "metadata": {}, "source": ["<img src=\"../../images/banners/python-advanced.png\" width=\"600\"/>"]}, {"cell_type": "markdown", "metadata": {}, "source": ["# <img src=\"../../images/logos/python.png\" width=\"23\"/> 07.3 The Meaning of Underscore (`_`) \n"]}, {"cell_type": "markdown", "metadata": {}, "source": ["## <img src=\"../../images/logos/toc.png\" width=\"20\"/> Table of Contents \n* [1. Single Leading Underscore: `_var`](#1._single_leading_underscore:_`_var`)\n* [2. Single Trailing Underscore: `var_`](#2._single_trailing_underscore:_`var_`)\n* [3. Double Leading Underscore: `__var`](#3._double_leading_underscore:_`__var`)\n* [4. Double Leading and Trailing Underscore: `__var__`](#4._double_leading_and_trailing_underscore:_`__var__`)\n* [5. Single Underscore: `_`](#5._single_underscore:_`_`)\n* [Summary](#summary)\n\n---"]}, {"cell_type": "markdown", "metadata": {}, "source": ["Single and double underscores have a meaning in Python variable and method names. Some of that meaning is merely by convention and intended as a hint to the programmer\u2014and some of it is enforced by the Python interpreter.\n", "\n", "- Single Leading Underscore: `_var`\n", "- Single Trailing Underscore: `var_`\n", "- Double Leading Underscore: `__var`\n", "- Double Leading and Trailing Underscore: `__var__`\n", "- Single Underscore: `_`"]}, {"cell_type": "markdown", "metadata": {}, "source": ["<a class=\"anchor\" id=\"1._single_leading_underscore:_`_var`\"></a>", "\n", "## 1. Single Leading Underscore: `_var`\n", "\n", "When it comes to variable and method names, the single underscore prefix has a meaning by convention only. It\u2019s a hint to the programmer\u2014and it means what the Python community agrees it should mean, but it does not affect the behavior of your programs."]}, {"cell_type": "markdown", "metadata": {}, "source": ["The underscore prefix is meant as a hint to another programmer that a variable or method starting with a single underscore is intended for internal use. This convention is [defined in PEP 8](http://pep8.org/#descriptive-naming-styles)."]}, {"cell_type": "markdown", "metadata": {}, "source": ["This isn\u2019t enforced by Python. Python does not have strong distinctions between \u201cprivate\u201d and \u201cpublic\u201d variables like Java does. It\u2019s like someone put up a tiny underscore warning sign that says:\n", "\n", "_Hey, this isn\u2019t really meant to be a part of the public interface of this class. Best to leave it alone._"]}, {"cell_type": "code", "execution_count": 11, "metadata": {}, "outputs": [], "source": ["class Test:\n", "    def __init__(self):\n", "        self.foo = 11\n", "        self._bar = 23"]}, {"cell_type": "code", "execution_count": 13, "metadata": {}, "outputs": [{"data": {"text/plain": ["(11, 23)"]}, "execution_count": 13, "metadata": {}, "output_type": "execute_result"}], "source": ["t = Test()\n", "t.foo, t._bar"]}, {"cell_type": "markdown", "metadata": {}, "source": ["The single underscore prefix in Python is merely an agreed upon convention\u2014at least when it comes to variable and method names."]}, {"cell_type": "markdown", "metadata": {}, "source": ["However, **leading underscores do impact how names get imported from modules**. Imagine you had the following code in a module called `my_module`:\n", "\n", "```python\n", "# This is my_module.py:\n", "\n", "def external_func():\n", "    return 23\n", "\n", "def _internal_func():\n", "    return 42\n", "```"]}, {"cell_type": "markdown", "metadata": {}, "source": ["Now if you use a wildcard import to import all names from the module, Python will not import names with a leading underscore (unless the module defines an `__all__` list that overrides this behavior):\n", "\n", "```python\n", ">>> from my_module import *\n", ">>> external_func()\n", "23\n", ">>> _internal_func()\n", "NameError: \"name '_internal_func' is not defined\"\n", "```"]}, {"cell_type": "markdown", "metadata": {}, "source": ["**Note:** wildcard imports should be avoided as they make it unclear which names are present in the namespace. It\u2019s better to stick to regular imports for the sake of clarity."]}, {"cell_type": "markdown", "metadata": {}, "source": ["Unlike wildcard imports, regular imports are not affected by the leading single underscore naming convention:\n", "\n", "```python\n", ">>> import my_module\n", ">>> my_module.external_func()\n", "23\n", ">>> my_module._internal_func()\n", "42\n", "```"]}, {"cell_type": "markdown", "metadata": {}, "source": ["If you stick to the PEP 8 recommendation that wildcard imports should be avoided, then really all you need to remember is this:\n", "\n", "> _Single underscores are a Python naming convention indicating a name is meant for internal use. It is generally not enforced by the Python interpreter and meant as a hint to the programmer only._"]}, {"cell_type": "markdown", "metadata": {}, "source": ["<a class=\"anchor\" id=\"2._single_trailing_underscore:_`var_`\"></a>", "\n", "## 2. Single Trailing Underscore: `var_`"]}, {"cell_type": "markdown", "metadata": {}, "source": ["Sometimes the most fitting name for a variable is already taken by a keyword. Therefore names like `class` or def cannot be used as variable names in Python. In this case you can append a single underscore to break the naming conflict:"]}, {"cell_type": "code", "execution_count": 27, "metadata": {}, "outputs": [{"ename": "SyntaxError", "evalue": "invalid syntax (295413822.py, line 1)", "output_type": "error", "traceback": ["\u001b[0;36m  File \u001b[0;32m\"/var/folders/b4/tsp68dlx1gz9xlnpgbx21ytc0000gn/T/ipykernel_24177/295413822.py\"\u001b[0;36m, line \u001b[0;32m1\u001b[0m\n\u001b[0;31m    def make_object(name, class):\u001b[0m\n\u001b[0m                              ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m invalid syntax\n"]}], "source": ["def make_object(name, class):\n", "    pass"]}, {"cell_type": "code", "execution_count": 29, "metadata": {}, "outputs": [], "source": ["def make_object(name, class_):\n", "    pass"]}, {"cell_type": "markdown", "metadata": {}, "source": ["In summary, a single trailing underscore (postfix) is used by convention to avoid naming conflicts with Python keywords. This convention is [explained in PEP 8](http://pep8.org/#descriptive-naming-styles)."]}, {"cell_type": "markdown", "metadata": {}, "source": ["<a class=\"anchor\" id=\"3._double_leading_underscore:_`__var`\"></a>", "\n", "## 3. Double Leading Underscore: `__var`"]}, {"cell_type": "markdown", "metadata": {}, "source": ["The naming patterns covered so far received their meaning from agreed upon conventions only. With Python class attributes (variables and methods) that start with double underscores, things are a little different."]}, {"cell_type": "markdown", "metadata": {}, "source": ["A double underscore prefix causes the Python interpreter to rewrite the attribute name in order to avoid naming conflicts in subclasses. This is also called name _mangling_ \u2014the interpreter changes the name of the variable in a way that makes it harder to create collisions when the class is extended later."]}, {"cell_type": "markdown", "metadata": {}, "source": ["Let\u2019s take a look at the attributes on this object using the [built-in `dir()`](https://docs.python.org/3/library/functions.html#dir) function:"]}, {"cell_type": "code", "execution_count": 48, "metadata": {}, "outputs": [{"data": {"text/plain": ["['_Test__baz',\n", " '__class__',\n", " '__delattr__',\n", " '__dict__',\n", " '__dir__',\n", " '__doc__',\n", " '__eq__',\n", " '__format__',\n", " '__ge__',\n", " '__getattribute__',\n", " '__gt__',\n", " '__hash__',\n", " '__init__',\n", " '__init_subclass__',\n", " '__le__',\n", " '__lt__',\n", " '__module__',\n", " '__ne__',\n", " '__new__',\n", " '__reduce__',\n", " '__reduce_ex__',\n", " '__repr__',\n", " '__setattr__',\n", " '__sizeof__',\n", " '__str__',\n", " '__subclasshook__',\n", " '__weakref__',\n", " '_bar',\n", " 'foo']"]}, "execution_count": 48, "metadata": {}, "output_type": "execute_result"}], "source": ["t = Test()\n", "dir(t)"]}, {"cell_type": "markdown", "metadata": {}, "source": ["This gives us a list with the object\u2019s attributes. Let\u2019s take this list and look for our original variable names `foo`, `_bar`, and `__baz`:\n", "\n", "- The `self.foo` variable appears unmodified as foo in the attribute list.\n", "- `self._bar` behaves the same way\u2014it shows up on the class as _bar. Like I said before, the leading underscore is just a convention in this case. A hint for the programmer.\n", "- However with `self.__baz`, things look a little different. When you search for `__baz` in that list you\u2019ll see that there is no variable with that name."]}, {"cell_type": "markdown", "metadata": {}, "source": ["If you look closely you\u2019ll see there\u2019s an attribute called \u200d`_Test__baz` on this object. This is the _name mangling_ that the Python interpreter applies. It does this to protect the variable from getting overridden in subclasses."]}, {"cell_type": "markdown", "metadata": {}, "source": ["Let\u2019s create another class that **extends** the Test class and attempts to override its existing attributes added in the constructor:"]}, {"cell_type": "code", "execution_count": 91, "metadata": {}, "outputs": [], "source": ["class ExtendedTest(Test):\n", "    def __init__(self):\n", "        super().__init__()\n", "        self.foo = 'overridden'\n", "        self._bar = 'overridden'\n", "        self.__baz = 'overridden'"]}, {"cell_type": "code", "execution_count": 88, "metadata": {}, "outputs": [{"data": {"text/plain": ["('overridden', 'overridden')"]}, "execution_count": 88, "metadata": {}, "output_type": "execute_result"}], "source": ["t2 = ExtendedTest()\n", "t2.foo, t2._bar"]}, {"cell_type": "code", "execution_count": 89, "metadata": {}, "outputs": [{"ename": "AttributeError", "evalue": "'ExtendedTest' object has no attribute '__baz'", "output_type": "error", "traceback": ["\u001b[0;31m---------------------------------------------------------------------------\u001b[0m", "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)", "\u001b[0;32m<ipython-input-89-ce8e845954f0>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mt2\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__baz\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m", "\u001b[0;31mAttributeError\u001b[0m: 'ExtendedTest' object has no attribute '__baz'"]}], "source": ["t2.__baz"]}, {"cell_type": "markdown", "metadata": {}, "source": ["As you can see `__baz` got turned into `_ExtendedTest__baz` to prevent accidental modification:"]}, {"cell_type": "code", "execution_count": 67, "metadata": {}, "outputs": [{"data": {"text/plain": ["'overridden'"]}, "execution_count": 67, "metadata": {}, "output_type": "execute_result"}], "source": ["t2._ExtendedTest__baz"]}, {"cell_type": "markdown", "metadata": {}, "source": ["But the original `_Test__baz` is also still around:"]}, {"cell_type": "code", "execution_count": 68, "metadata": {}, "outputs": [{"data": {"text/plain": ["23"]}, "execution_count": 68, "metadata": {}, "output_type": "execute_result"}], "source": ["t2._Test__baz"]}, {"cell_type": "markdown", "metadata": {}, "source": ["Double underscore name mangling is fully transparent to the programmer. Take a look at the following example that will confirm this:"]}, {"cell_type": "code", "execution_count": 25, "metadata": {}, "outputs": [], "source": ["class ManglingTest:\n", "    def __init__(self):\n", "        self.__mangled = 'hello'\n", "\n", "    def get_mangled(self):\n", "        return self.__mangled"]}, {"cell_type": "code", "execution_count": 26, "metadata": {}, "outputs": [{"data": {"text/plain": ["'hello'"]}, "execution_count": 26, "metadata": {}, "output_type": "execute_result"}], "source": ["ManglingTest().get_mangled()"]}, {"cell_type": "code", "execution_count": 27, "metadata": {}, "outputs": [{"ename": "AttributeError", "evalue": "'ManglingTest' object has no attribute '__mangled'", "output_type": "error", "traceback": ["\u001b[0;31m---------------------------------------------------------------------------\u001b[0m", "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)", "\u001b[0;32m<ipython-input-27-14d8b1db7c4f>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mManglingTest\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__mangled\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m", "\u001b[0;31mAttributeError\u001b[0m: 'ManglingTest' object has no attribute '__mangled'"]}], "source": ["ManglingTest().__mangled"]}, {"cell_type": "markdown", "metadata": {}, "source": ["**Does name mangling also apply to method names?** It sure does\u2014name mangling affects all names that start with two underscore characters (\u201cdunders\u201d) in a class context:"]}, {"cell_type": "code", "execution_count": 76, "metadata": {}, "outputs": [], "source": ["class MangledMethod:\n", "    def __method(self):\n", "        return 42\n", "\n", "    def call_it(self):\n", "        return self.__method()"]}, {"cell_type": "code", "execution_count": 79, "metadata": {}, "outputs": [{"ename": "AttributeError", "evalue": "'MangledMethod' object has no attribute '__method'", "output_type": "error", "traceback": ["\u001b[0;31m---------------------------------------------------------------------------\u001b[0m", "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)", "\u001b[0;32m/var/folders/b4/tsp68dlx1gz9xlnpgbx21ytc0000gn/T/ipykernel_24177/2847256654.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mMangledMethod\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__method\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m", "\u001b[0;31mAttributeError\u001b[0m: 'MangledMethod' object has no attribute '__method'"]}], "source": ["MangledMethod().__method()"]}, {"cell_type": "code", "execution_count": 78, "metadata": {}, "outputs": [{"data": {"text/plain": ["42"]}, "execution_count": 78, "metadata": {}, "output_type": "execute_result"}], "source": ["MangledMethod().call_it()"]}, {"cell_type": "markdown", "metadata": {}, "source": ["<a class=\"anchor\" id=\"4._double_leading_and_trailing_underscore:_`__var__`\"></a>", "\n", "## 4. Double Leading and Trailing Underscore: `__var__`"]}, {"cell_type": "markdown", "metadata": {}, "source": ["Perhaps surprisingly, name mangling is not applied if a name starts and ends with double underscores. Variables surrounded by a double underscore prefix and postfix are left unscathed by the Python interpeter:"]}, {"cell_type": "code", "execution_count": 102, "metadata": {}, "outputs": [], "source": ["class PrefixPostfixTest:\n", "    def __init__(self):\n", "        self.__bam__ = 42"]}, {"cell_type": "code", "execution_count": 103, "metadata": {}, "outputs": [{"data": {"text/plain": ["42"]}, "execution_count": 103, "metadata": {}, "output_type": "execute_result"}], "source": ["PrefixPostfixTest().__bam__"]}, {"cell_type": "markdown", "metadata": {}, "source": ["However, names that have both leading and trailing double underscores are reserved for special use in the language. This rule covers things like `__init__` for object constructors, or `__call__` to make an object callable."]}, {"cell_type": "markdown", "metadata": {}, "source": ["<a class=\"anchor\" id=\"5._single_underscore:_`_`\"></a>", "\n", "## 5. Single Underscore: `_`"]}, {"cell_type": "markdown", "metadata": {}, "source": ["Per convention, a single standalone underscore is sometimes used as a name to indicate that a variable is temporary or insignificant."]}, {"cell_type": "markdown", "metadata": {}, "source": ["For example, in the following loop we don\u2019t need access to the running index and we can use `_` to indicate that it is just a temporary value:"]}, {"cell_type": "code", "execution_count": 25, "metadata": {}, "outputs": [{"name": "stdout", "output_type": "stream", "text": ["Hello, World.\n", "Hello, World.\n", "Hello, World.\n", "Hello, World.\n", "Hello, World.\n"]}], "source": ["for _ in range(5):\n", "    print('Hello, World.')"]}, {"cell_type": "markdown", "metadata": {}, "source": ["You can also use single underscores in unpacking expressions as a \u201cdon\u2019t care\u201d variable to ignore particular values. Again, this meaning is \u201cper convention\u201d only and there\u2019s no special behavior triggered in the Python interpreter. The single underscore is simply a valid variable name that\u2019s sometimes used for this purpose."]}, {"cell_type": "markdown", "metadata": {}, "source": ["In the following code example I\u2019m unpacking a car tuple into separate variables but I\u2019m only interested in the values for color and mileage. However, in order for the unpacking expression to succeed I need to assign all values contained in the tuple to variables. That\u2019s where `_` is useful as a placeholder variable:"]}, {"cell_type": "code", "execution_count": 116, "metadata": {}, "outputs": [], "source": ["car = ('red', 'auto', 12, 3812.4)\n", "color, _, _, mileage = car"]}, {"cell_type": "code", "execution_count": 117, "metadata": {}, "outputs": [{"data": {"text/plain": ["'red'"]}, "execution_count": 117, "metadata": {}, "output_type": "execute_result"}], "source": ["color"]}, {"cell_type": "code", "execution_count": 118, "metadata": {"scrolled": true}, "outputs": [{"data": {"text/plain": ["3812.4"]}, "execution_count": 118, "metadata": {}, "output_type": "execute_result"}], "source": ["mileage"]}, {"cell_type": "code", "execution_count": 119, "metadata": {}, "outputs": [{"data": {"text/plain": ["12"]}, "execution_count": 119, "metadata": {}, "output_type": "execute_result"}], "source": ["_"]}, {"cell_type": "code", "execution_count": 120, "metadata": {}, "outputs": [{"data": {"text/plain": ["3000000000"]}, "execution_count": 120, "metadata": {}, "output_type": "execute_result"}], "source": ["3_000_000_000"]}, {"cell_type": "markdown", "metadata": {}, "source": ["<a class=\"anchor\" id=\"summary\"></a>", "\n", "## Summary"]}, {"cell_type": "markdown", "metadata": {}, "source": ["|Pattern|Example|Meaning|\n", "|:--|:--|:--|\n", "|Single Leading Underscore|`_var`|Naming convention indicating a name is meant for internal use. Generally not enforced by the Python interpreter (except in wildcard imports) and meant as a hint to the programmer only.|\n", "|Single Trailing Underscore|`var_`|Used by convention to avoid naming conflicts with Python keywords.|\n", "|Double Leading Underscore|`__var`|Triggers name mangling when used in a class context. Enforced by the Python interpreter.|\n", "|Double Leading and Trailing Underscore|`__var__`|Indicates special methods defined by the Python language. Avoid this naming scheme for your own attributes.|\n", "|Single Underscore|`_`|Sometimes used as a name for temporary or insignificant variables (\u201cdon\u2019t care\u201d). Also: The result of the last expression in a Python REPL.|"]}, {"cell_type": "markdown", "metadata": {}, "source": ["[Reference](https://dbader.org/blog/meaning-of-underscores-in-python)"]}], "metadata": {"kernelspec": {"display_name": "Python 3 (ipykernel)", "language": "python", "name": "python3"}, "language_info": {"codemirror_mode": {"name": "ipython", "version": 3}, "file_extension": ".py", "mimetype": "text/x-python", "name": "python", "nbconvert_exporter": "python", "pygments_lexer": "ipython3", "version": "3.7.10"}}, "nbformat": 4, "nbformat_minor": 4}
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<img src=\"../../images/banners/python-advanced.png\" width=\"600\"/>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# <img src=\"../../images/logos/python.png\" width=\"23\"/> 07.3 The Meaning of Underscore (`_`) \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## <img src=\"../../images/logos/toc.png\" width=\"20\"/> Table of Contents \n",
+    "* [1. Single Leading Underscore: `_var`](#1._single_leading_underscore:_`_var`)\n",
+    "* [2. Single Trailing Underscore: `var_`](#2._single_trailing_underscore:_`var_`)\n",
+    "* [3. Double Leading Underscore: `__var`](#3._double_leading_underscore:_`__var`)\n",
+    "* [4. Double Leading and Trailing Underscore: `__var__`](#4._double_leading_and_trailing_underscore:_`__var__`)\n",
+    "* [5. Single Underscore: `_`](#5._single_underscore:_`_`)\n",
+    "* [Summary](#summary)\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Single and double underscores have a meaning in Python variable and method names. Some of that meaning is merely by convention and intended as a hint to the programmer—and some of it is enforced by the Python interpreter.\n",
+    "\n",
+    "- Single Leading Underscore: `_var`\n",
+    "- Single Trailing Underscore: `var_`\n",
+    "- Double Leading Underscore: `__var`\n",
+    "- Double Leading and Trailing Underscore: `__var__`\n",
+    "- Single Underscore: `_`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a class=\"anchor\" id=\"1._single_leading_underscore:_`_var`\"></a>\n",
+    "## 1. Single Leading Underscore: `_var`\n",
+    "\n",
+    "When it comes to variable and method names, the single underscore prefix has a meaning by convention only. It’s a hint to the programmer—and it means what the Python community agrees it should mean, but it does not affect the behavior of your programs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The underscore prefix is meant as a hint to another programmer that a variable or method starting with a single underscore is intended for internal use. This convention is [defined in PEP 8](http://pep8.org/#descriptive-naming-styles)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This isn’t enforced by Python. Python does not have strong distinctions between “private” and “public” variables like Java does. It’s like someone put up a tiny underscore warning sign that says:\n",
+    "\n",
+    "_Hey, this isn’t really meant to be a part of the public interface of this class. Best to leave it alone._"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Test:\n",
+    "    def __init__(self):\n",
+    "        self.foo = 11\n",
+    "        self._bar = 23"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(11, 23)"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "t = Test()\n",
+    "t.foo, t._bar"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The single underscore prefix in Python is merely an agreed upon convention—at least when it comes to variable and method names."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "However, **leading underscores do impact how names get imported from modules**. Imagine you had the following code in a module called `my_module`:\n",
+    "\n",
+    "```python\n",
+    "# This is my_module.py:\n",
+    "\n",
+    "def external_func():\n",
+    "    return 23\n",
+    "\n",
+    "def _internal_func():\n",
+    "    return 42\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now if you use a wildcard import to import all names from the module, Python will not import names with a leading underscore (unless the module defines an `__all__` list that overrides this behavior):\n",
+    "\n",
+    "```python\n",
+    ">>> from my_module import *\n",
+    ">>> external_func()\n",
+    "23\n",
+    ">>> _internal_func()\n",
+    "NameError: \"name '_internal_func' is not defined\"\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Note:** wildcard imports should be avoided as they make it unclear which names are present in the namespace. It’s better to stick to regular imports for the sake of clarity."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Unlike wildcard imports, regular imports are not affected by the leading single underscore naming convention:\n",
+    "\n",
+    "```python\n",
+    ">>> import my_module\n",
+    ">>> my_module.external_func()\n",
+    "23\n",
+    ">>> my_module._internal_func()\n",
+    "42\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you stick to the PEP 8 recommendation that wildcard imports should be avoided, then really all you need to remember is this:\n",
+    "> _Single underscores are a Python naming convention indicating a name is meant for internal use. It is generally not enforced by the Python interpreter and meant as a hint to the programmer only._"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a class=\"anchor\" id=\"2._single_trailing_underscore:_`var_`\"></a>\n",
+    "## 2. Single Trailing Underscore: `var_`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Sometimes the most fitting name for a variable is already taken by a keyword. Therefore names like `class` or def cannot be used as variable names in Python. In this case you can append a single underscore to break the naming conflict:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "SyntaxError",
+     "evalue": "invalid syntax (295413822.py, line 1)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;36m  File \u001b[0;32m\"/var/folders/b4/tsp68dlx1gz9xlnpgbx21ytc0000gn/T/ipykernel_24177/295413822.py\"\u001b[0;36m, line \u001b[0;32m1\u001b[0m\n\u001b[0;31m    def make_object(name, class):\u001b[0m\n\u001b[0m                              ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m invalid syntax\n"
+     ]
+    }
+   ],
+   "source": [
+    "def make_object(name, class):\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def make_object(name, class_):\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In summary, a single trailing underscore (postfix) is used by convention to avoid naming conflicts with Python keywords. This convention is [explained in PEP 8](http://pep8.org/#descriptive-naming-styles)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a class=\"anchor\" id=\"3._double_leading_underscore:_`__var`\"></a>\n",
+    "## 3. Double Leading Underscore: `__var`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The naming patterns covered so far received their meaning from agreed upon conventions only. With Python class attributes (variables and methods) that start with double underscores, things are a little different."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A double underscore prefix causes the Python interpreter to rewrite the attribute name in order to avoid naming conflicts in subclasses. This is also called name _mangling_ —the interpreter changes the name of the variable in a way that makes it harder to create collisions when the class is extended later."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let’s take a look at the attributes on this object using the [built-in `dir()`](https://docs.python.org/3/library/functions.html#dir) function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['_Test__baz',\n",
+       " '__class__',\n",
+       " '__delattr__',\n",
+       " '__dict__',\n",
+       " '__dir__',\n",
+       " '__doc__',\n",
+       " '__eq__',\n",
+       " '__format__',\n",
+       " '__ge__',\n",
+       " '__getattribute__',\n",
+       " '__gt__',\n",
+       " '__hash__',\n",
+       " '__init__',\n",
+       " '__init_subclass__',\n",
+       " '__le__',\n",
+       " '__lt__',\n",
+       " '__module__',\n",
+       " '__ne__',\n",
+       " '__new__',\n",
+       " '__reduce__',\n",
+       " '__reduce_ex__',\n",
+       " '__repr__',\n",
+       " '__setattr__',\n",
+       " '__sizeof__',\n",
+       " '__str__',\n",
+       " '__subclasshook__',\n",
+       " '__weakref__',\n",
+       " '_bar',\n",
+       " 'foo']"
+      ]
+     },
+     "execution_count": 48,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "t = Test()\n",
+    "dir(t)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This gives us a list with the object’s attributes. Let’s take this list and look for our original variable names `foo`, `_bar`, and `__baz`:\n",
+    "\n",
+    "- The `self.foo` variable appears unmodified as foo in the attribute list.\n",
+    "- `self._bar` behaves the same way—it shows up on the class as _bar. Like I said before, the leading underscore is just a convention in this case. A hint for the programmer.\n",
+    "- However with `self.__baz`, things look a little different. When you search for `__baz` in that list you’ll see that there is no variable with that name."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you look closely you’ll see there’s an attribute called ‍`_Test__baz` on this object. This is the _name mangling_ that the Python interpreter applies. It does this to protect the variable from getting overridden in subclasses."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let’s create another class that **extends** the Test class and attempts to override its existing attributes added in the constructor:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 91,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class ExtendedTest(Test):\n",
+    "    def __init__(self):\n",
+    "        super().__init__()\n",
+    "        self.foo = 'overridden'\n",
+    "        self._bar = 'overridden'\n",
+    "        self.__baz = 'overridden'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 88,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('overridden', 'overridden')"
+      ]
+     },
+     "execution_count": 88,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "t2 = ExtendedTest()\n",
+    "t2.foo, t2._bar"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 89,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "AttributeError",
+     "evalue": "'ExtendedTest' object has no attribute '__baz'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-89-ce8e845954f0>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mt2\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__baz\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m: 'ExtendedTest' object has no attribute '__baz'"
+     ]
+    }
+   ],
+   "source": [
+    "t2.__baz"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As you can see `__baz` got turned into `_ExtendedTest__baz` to prevent accidental modification:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 67,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'overridden'"
+      ]
+     },
+     "execution_count": 67,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "t2._ExtendedTest__baz"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "But the original `_Test__baz` is also still around:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 68,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "23"
+      ]
+     },
+     "execution_count": 68,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "t2._Test__baz"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Double underscore name mangling is fully transparent to the programmer. Take a look at the following example that will confirm this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class ManglingTest:\n",
+    "    def __init__(self):\n",
+    "        self.__mangled = 'hello'\n",
+    "\n",
+    "    def get_mangled(self):\n",
+    "        return self.__mangled"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'hello'"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ManglingTest().get_mangled()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "AttributeError",
+     "evalue": "'ManglingTest' object has no attribute '__mangled'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-27-14d8b1db7c4f>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mManglingTest\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__mangled\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m: 'ManglingTest' object has no attribute '__mangled'"
+     ]
+    }
+   ],
+   "source": [
+    "ManglingTest().__mangled"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Does name mangling also apply to method names?** It sure does—name mangling affects all names that start with two underscore characters (“dunders”) in a class context:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class MangledMethod:\n",
+    "    def __method(self):\n",
+    "        return 42\n",
+    "\n",
+    "    def call_it(self):\n",
+    "        return self.__method()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 79,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "AttributeError",
+     "evalue": "'MangledMethod' object has no attribute '__method'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[0;32m/var/folders/b4/tsp68dlx1gz9xlnpgbx21ytc0000gn/T/ipykernel_24177/2847256654.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mMangledMethod\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__method\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m: 'MangledMethod' object has no attribute '__method'"
+     ]
+    }
+   ],
+   "source": [
+    "MangledMethod().__method()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 78,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "42"
+      ]
+     },
+     "execution_count": 78,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "MangledMethod().call_it()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a class=\"anchor\" id=\"4._double_leading_and_trailing_underscore:_`__var__`\"></a>\n",
+    "## 4. Double Leading and Trailing Underscore: `__var__`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Perhaps surprisingly, name mangling is not applied if a name starts and ends with double underscores. Variables surrounded by a double underscore prefix and postfix are left unscathed by the Python interpeter:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 102,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class PrefixPostfixTest:\n",
+    "    def __init__(self):\n",
+    "        self.__bam__ = 42"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 103,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "42"
+      ]
+     },
+     "execution_count": 103,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "PrefixPostfixTest().__bam__"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "However, names that have both leading and trailing double underscores are reserved for special use in the language. This rule covers things like `__init__` for object constructors, or `__call__` to make an object callable."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a class=\"anchor\" id=\"5._single_underscore:_`_`\"></a>\n",
+    "## 5. Single Underscore: `_`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Per convention, a single standalone underscore is sometimes used as a name to indicate that a variable is temporary or insignificant."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For example, in the following loop we don’t need access to the running index and we can use `_` to indicate that it is just a temporary value:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hello, World.\n",
+      "Hello, World.\n",
+      "Hello, World.\n",
+      "Hello, World.\n",
+      "Hello, World.\n"
+     ]
+    }
+   ],
+   "source": [
+    "for _ in range(5):\n",
+    "    print('Hello, World.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also use single underscores in unpacking expressions as a “don’t care” variable to ignore particular values. Again, this meaning is “per convention” only and there’s no special behavior triggered in the Python interpreter. The single underscore is simply a valid variable name that’s sometimes used for this purpose."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the following code example I’m unpacking a car tuple into separate variables but I’m only interested in the values for color and mileage. However, in order for the unpacking expression to succeed I need to assign all values contained in the tuple to variables. That’s where `_` is useful as a placeholder variable:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "car = ('red', 'auto', 12, 3812.4)\n",
+    "color, _, _, mileage = car"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'red'"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "color"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3812.4"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mileage"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "12"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "_"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#####  Single Underscores in Numeric Literals\n",
+    "Python allows you to put underscores in numbers for convenience. They're used to separate groups of numbers, much like commas do in non-programming. Underscores are completely ignored in numbers, much like comments. So this:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3000000000"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "3_000_000_000"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Single Underscores to represent the last expression in the interpreter\n",
+    "According to [Python doc](https://docs.python.org/3/reference/lexical_analysis.html#reserved-classes-of-identifiers) , the special identifier _ is used in the interactive interpreter to store the result of the last evaluation. It is stored in the builtin module.\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here is an example. At first, we check that _ is not stored in the builtin module, then we write a single expression without a variable name. If we check the builtin module again, we will find _ in the module and the value is the last evaluation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    ">>>'_' in dir(__builtins__)\n",
+    "False\n",
+    ">>> 1+1\n",
+    "2\n",
+    ">>> '_' in dir(__builtins__)\n",
+    "True\n",
+    ">>> _\n",
+    "2\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a class=\"anchor\" id=\"summary\"></a>\n",
+    "## Summary"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "|Pattern|Example|Meaning|\n",
+    "|:--|:--|:--|\n",
+    "|Single Leading Underscore|`_var`|Naming convention indicating a name is meant for internal use. Generally not enforced by the Python interpreter (except in wildcard imports) and meant as a hint to the programmer only.|\n",
+    "|Single Trailing Underscore|`var_`|Used by convention to avoid naming conflicts with Python keywords.|\n",
+    "|Double Leading Underscore|`__var`|Triggers name mangling when used in a class context. Enforced by the Python interpreter.|\n",
+    "|Double Leading and Trailing Underscore|`__var__`|Indicates special methods defined by the Python language. Avoid this naming scheme for your own attributes.|\n",
+    "|Single Underscore|`_`|Sometimes used as a name for temporary or insignificant variables (“don’t care”). Also: The result of the last expression in a Python REPL.|"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Reference](https://dbader.org/blog/meaning-of-underscores-in-python)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
added two subtitles in the meaning of underscore tutorial in part "5. Single Underscore: _" 
which are "Single Underscores in Numeric Literals" and "Single Underscores to represent the last expression in the interpreter¶"